### PR TITLE
Feature/gpx 697

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-## Microservice for the purpose of simulating and testing health-endpoints, logging and LoadTesting. Furthermore simulating and monitoring traffic between several microservices.!
+## Microservice for the purpose of simulating and testing health-endpoints, logging and LoadTesting. Furthermore simulating and monitoring traffic between several microservices.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 ## Microservice for the purpose of simulating and testing health-endpoints, logging and LoadTesting. Furthermore simulating and monitoring traffic between several microservices.
 
-let's go
+let's go!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
 ## Microservice for the purpose of simulating and testing health-endpoints, logging and LoadTesting. Furthermore simulating and monitoring traffic between several microservices.
 
-let's go!

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-## Microservice for the purpose of simulating and testing health-endpoints, logging and LoadTesting. Furthermore simulating and monitoring traffic between several microservices.
+## Microservice for the purpose of simulating and testing health-endpoints, logging and LoadTesting. Furthermore simulating and monitoring traffic between several microservices.!
 

--- a/src/main/java/at/gepardec/rest/TestAlert.java
+++ b/src/main/java/at/gepardec/rest/TestAlert.java
@@ -27,7 +27,7 @@ public class TestAlert {
     TestAlert(MeterRegistry registry) {
         this.testAlertActive = new AtomicInteger(0);
         Gauge.builder("demo.microservice.test.alert.active", testAlertActive, AtomicInteger::doubleValue)
-                .description("This is a custom metric that is toggled on and off via the /test-alert/ endpoint.")
+                .description("This is a custom metric that is toggled on and off via the /test-alert/on or /test-alert/on endpoint.")
                 .register(registry);
     }
 

--- a/src/main/java/at/gepardec/rest/TestAlert.java
+++ b/src/main/java/at/gepardec/rest/TestAlert.java
@@ -1,5 +1,7 @@
 package at.gepardec.rest;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -7,27 +9,35 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.runtime.StartupEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
 
 @Path("/test-alert")
+@ApplicationScoped
 public class TestAlert {
 
-
-    AtomicInteger testalertactive;
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogErrorGeneratorResource.class);
+    AtomicInteger testAlertActive;
 
     TestAlert(MeterRegistry registry) {
-        this.testalertactive = new AtomicInteger(0);
-        registry.gauge("test.alert", testalertactive);
+        this.testAlertActive = new AtomicInteger(0);
+        registry.gauge("demo.microservice.test.alert.active", testAlertActive);
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        LOGGER.info("Starting TestAlert endpoint");
     }
 
     @GET
     @Path("/on")
     @Produces(MediaType.TEXT_PLAIN)
-    public Response turnOnAlert() {
+    public Response turnAlertOn() {
 
-        testalertactive.set(1);
+        testAlertActive.set(1);
         return Response
                 .status(200)
                 .entity("Alert turned on!")
@@ -37,9 +47,9 @@ public class TestAlert {
     @GET
     @Path("/off")
     @Produces(MediaType.TEXT_PLAIN)
-    public Response turnOffAlert() {
+    public Response turnAlertOff() {
 
-        testalertactive.set(0);
+        testAlertActive.set(0);
         return Response
                 .status(200)
                 .entity("Alert turned off!")

--- a/src/main/java/at/gepardec/rest/TestAlert.java
+++ b/src/main/java/at/gepardec/rest/TestAlert.java
@@ -1,0 +1,49 @@
+package at.gepardec.rest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+@Path("/test-alert")
+public class TestAlert {
+
+
+    AtomicInteger testalertactive;
+
+    TestAlert(MeterRegistry registry) {
+        this.testalertactive = new AtomicInteger(0);
+        registry.gauge("test.alert", testalertactive);
+    }
+
+    @GET
+    @Path("/on")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response turnOnAlert() {
+
+        testalertactive.set(1);
+        return Response
+                .status(200)
+                .entity("Alert turned on!")
+                .build();
+    }
+
+    @GET
+    @Path("/off")
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response turnOffAlert() {
+
+        testalertactive.set(0);
+        return Response
+                .status(200)
+                .entity("Alert turned off!")
+                .build();
+    }
+
+}

--- a/src/main/java/at/gepardec/rest/TestAlert.java
+++ b/src/main/java/at/gepardec/rest/TestAlert.java
@@ -27,7 +27,7 @@ public class TestAlert {
     TestAlert(MeterRegistry registry) {
         this.testAlertActive = new AtomicInteger(0);
         Gauge.builder("demo.microservice.test.alert.active", testAlertActive, AtomicInteger::doubleValue)
-                .description("This is a custom metric that is toggled on and off via the /test-alert/on or /test-alert/on endpoint.")
+                .description("This is a custom metric that is toggled on and off via the /test-alert/on or /test-alert/off endpoint.")
                 .register(registry);
     }
 

--- a/src/main/java/at/gepardec/rest/TestAlert.java
+++ b/src/main/java/at/gepardec/rest/TestAlert.java
@@ -8,6 +8,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.runtime.StartupEvent;
 import org.slf4j.Logger;
@@ -25,7 +26,9 @@ public class TestAlert {
 
     TestAlert(MeterRegistry registry) {
         this.testAlertActive = new AtomicInteger(0);
-        registry.gauge("demo.microservice.test.alert.active", testAlertActive);
+        Gauge.builder("demo.microservice.test.alert.active", testAlertActive, AtomicInteger::doubleValue)
+                .description("This is a custom metric that is toggled on and off via the /test-alert/ endpoint.")
+                .register(registry);
     }
 
     void onStart(@Observes StartupEvent ev) {


### PR DESCRIPTION
Implement a new REST Endpoint that allows us to toggle the _test_alert_ metric. This metric will be used to trigger alerts allowing us demonstrate out alerting stack 